### PR TITLE
Pal 230 remove process method from services

### DIFF
--- a/cache-service-test/src/main/java/uk/gov/gchq/palisade/integrationtests/cache/service/CacheService.java
+++ b/cache-service-test/src/main/java/uk/gov/gchq/palisade/integrationtests/cache/service/CacheService.java
@@ -20,7 +20,6 @@ import uk.gov.gchq.palisade.integrationtests.cache.request.GetCacheRequest;
 import uk.gov.gchq.palisade.integrationtests.cache.request.ListCacheRequest;
 import uk.gov.gchq.palisade.integrationtests.cache.request.RemoveCacheRequest;
 import uk.gov.gchq.palisade.service.Service;
-import uk.gov.gchq.palisade.service.request.Request;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -76,20 +75,4 @@ public interface CacheService extends Service {
      */
     CompletableFuture<Boolean> remove(RemoveCacheRequest request);
 
-    @Override
-    default CompletableFuture<?> process(final Request request) {
-        if (request instanceof AddCacheRequest) {
-            return add((AddCacheRequest) request);
-        }
-        if (request instanceof GetCacheRequest) {
-            return get((GetCacheRequest) request);
-        }
-        if (request instanceof ListCacheRequest) {
-            return list((ListCacheRequest) request);
-        }
-        if (request instanceof RemoveCacheRequest) {
-            return remove((RemoveCacheRequest) request);
-        }
-        return Service.super.process(request);
-    }
 }

--- a/cache-service-test/src/test/java/uk/gov/gchq/palisade/integrationtests/cache/service/SimpleCacheServiceTest.java
+++ b/cache-service-test/src/test/java/uk/gov/gchq/palisade/integrationtests/cache/service/SimpleCacheServiceTest.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.palisade.integrationtests.cache.repository.BackingStore;
 import uk.gov.gchq.palisade.integrationtests.cache.repository.HashMapBackingStore;
-import uk.gov.gchq.palisade.service.ServiceState;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -35,7 +34,6 @@ public class SimpleCacheServiceTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleCacheServiceTest.class);
 
     private SimpleCacheService cacheService = new SimpleCacheService();
-    private ServiceState serviceState = new ServiceState();
     private BackingStore store = new HashMapBackingStore();
     private Duration maxLocalTTL = Duration.of(5, ChronoUnit.MINUTES);
 }

--- a/palisade-service-test/src/test/java/uk/gov/gchq/palisade/integrationtests/palisade/BaseTestEnvironment.java
+++ b/palisade-service-test/src/test/java/uk/gov/gchq/palisade/integrationtests/palisade/BaseTestEnvironment.java
@@ -55,10 +55,6 @@ public class BaseTestEnvironment {
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "class")
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
     public static class StubService implements Service {
-        @Override
-        public CompletableFuture<String> process(final Request request) {
-            return CompletableFuture.completedFuture(request.getId().getId());
-        }
 
         @Override
         public boolean equals(final Object obj) {


### PR DESCRIPTION
Process method has been removed. This is a legacy method that is no longer used.