### PR TITLE
Pal 607 health indicator

### DIFF
--- a/palisade-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/palisade/service/PalisadeComponentTest.java
+++ b/palisade-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/palisade/service/PalisadeComponentTest.java
@@ -58,8 +58,7 @@ import static org.junit.Assume.assumeTrue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = PalisadeApplication.class, webEnvironment = WebEnvironment.DEFINED_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-//reset db after each test
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) //reset db after each test
 @EnableJpaRepositories(basePackages = {"uk.gov.gchq.palisade.service.palisade.repository"})
 public class PalisadeComponentTest {
 

--- a/palisade-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/palisade/service/PalisadeComponentTest.java
+++ b/palisade-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/palisade/service/PalisadeComponentTest.java
@@ -58,7 +58,8 @@ import static org.junit.Assume.assumeTrue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = PalisadeApplication.class, webEnvironment = WebEnvironment.DEFINED_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) //reset db after each test
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+//reset db after each test
 @EnableJpaRepositories(basePackages = {"uk.gov.gchq.palisade.service.palisade.repository"})
 public class PalisadeComponentTest {
 
@@ -103,43 +104,6 @@ public class PalisadeComponentTest {
         final String health = this.restTemplate.getForObject("/actuator/health", String.class);
         assertThat(health, is(equalTo("{\"status\":\"UP\"}")));
     }
-
-    @Test
-    public void allServicesDown() {
-        //Given all services are down
-        auditMock.stop();
-        policyMock.stop();
-        resourceMock.stop();
-        userMock.stop();
-        //Then the Palisade Service also reports down.
-        final String downHealth = this.restTemplate.getForObject("/actuator/health", String.class);
-        assertThat(downHealth, is(equalTo("{\"status\":\"DOWN\"}")));
-
-        //When the services start one by one
-        auditMock.start();
-        //Then Palisade service still shows as down
-        final String auditDownHealth = this.restTemplate.getForObject("/actuator/health", String.class);
-        assertThat(auditDownHealth, is(equalTo("{\"status\":\"DOWN\"}")));
-
-        //When the services start one by one
-        policyMock.start();
-        //Then Palisade service still shows as down
-        final String policyDownHealth = this.restTemplate.getForObject("/actuator/health", String.class);
-        assertThat(policyDownHealth, is(equalTo("{\"status\":\"DOWN\"}")));
-
-        //When the resource service starts
-        resourceMock.start();
-        //Then Palisade service still shows as down
-        final String resourceDownHealth = this.restTemplate.getForObject("/actuator/health", String.class);
-        assertThat(resourceDownHealth, is(equalTo("{\"status\":\"DOWN\"}")));
-
-        //When the final service starts
-        userMock.start();
-        //Then Palisade service shows as up
-        final String allUpHealth = this.restTemplate.getForObject("/actuator/health", String.class);
-        assertThat(allUpHealth, is(equalTo("{\"status\":\"UP\"}")));
-    }
-
 
     @Test
     public void registerDataRequestTest() {


### PR DESCRIPTION
Health indicator only runs under eureka profile and therefore requires eureka to be running to get the right port numbers etc. This has become a test of our discovery service which is not needed. 