### PR TITLE
PAL-619  Refactor existing Policy integration tests are are not working

### DIFF
--- a/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyCachingProxyTest.java
+++ b/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyCachingProxyTest.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import uk.gov.gchq.palisade.policy.PassThroughRule;
@@ -31,9 +33,9 @@ import uk.gov.gchq.palisade.resource.StubResource;
 import uk.gov.gchq.palisade.resource.impl.FileResource;
 import uk.gov.gchq.palisade.resource.impl.SystemResource;
 import uk.gov.gchq.palisade.service.policy.PolicyApplication;
-import uk.gov.gchq.palisade.service.policy.request.Policy;
 import uk.gov.gchq.palisade.service.policy.service.PolicyService;
 import uk.gov.gchq.palisade.service.policy.service.PolicyServiceCachingProxy;
+import uk.gov.gchq.palisade.service.request.Policy;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -44,11 +46,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = PolicyApplication.class, webEnvironment = WebEnvironment.NONE)
+@Import(PolicyTestConfiguration.class)
+@SpringBootTest(classes = {   PolicyApplication.class}, webEnvironment = WebEnvironment.NONE)
+@ComponentScan(basePackages = "uk.gov.gchq.palisade")
 public class PolicyCachingProxyTest extends PolicyTestCommon {
 
     @Autowired
     private PolicyServiceCachingProxy cacheProxy;
+
     @Autowired
     @Qualifier("impl")
     private PolicyService policyService;

--- a/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyComponentTest.java
+++ b/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyComponentTest.java
@@ -25,17 +25,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import uk.gov.gchq.palisade.RequestId;
 import uk.gov.gchq.palisade.resource.LeafResource;
 import uk.gov.gchq.palisade.rule.Rules;
+import uk.gov.gchq.palisade.service.PolicyConfiguration;
 import uk.gov.gchq.palisade.service.policy.PolicyApplication;
 import uk.gov.gchq.palisade.service.policy.request.CanAccessRequest;
 import uk.gov.gchq.palisade.service.policy.request.CanAccessResponse;
 import uk.gov.gchq.palisade.service.policy.request.GetPolicyRequest;
 import uk.gov.gchq.palisade.service.policy.request.SetResourcePolicyRequest;
 import uk.gov.gchq.palisade.service.policy.service.PolicyService;
+import uk.gov.gchq.palisade.service.policy.web.PolicyController;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -48,10 +50,15 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringRunner.class)
+@Import(PolicyTestConfiguration.class)
 @EnableFeignClients
-@SpringBootTest(classes = PolicyApplication.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = {PolicyApplication.class, PolicyController.class, PolicyConfiguration.class}, webEnvironment = WebEnvironment.DEFINED_PORT)
 public class PolicyComponentTest extends PolicyTestCommon {
     private static final Logger LOGGER = LoggerFactory.getLogger(PolicyComponentTest.class);
+
+
+    @Autowired
+    PolicyController policyController;
 
     @Autowired
     Map<String, PolicyService> serviceMap;
@@ -79,12 +86,10 @@ public class PolicyComponentTest extends PolicyTestCommon {
 
         // When a resource is added
         SetResourcePolicyRequest addRequest = new SetResourcePolicyRequest().resource(NEW_FILE).policy(PASS_THROUGH_POLICY);
-        addRequest.originalRequestId(new RequestId().id("test-id"));
         policyClient.setResourcePolicyAsync(addRequest);
 
         // Given it is accessible
         CanAccessRequest accessRequest = new CanAccessRequest().user(USER).resources(resources).context(CONTEXT);
-        accessRequest.originalRequestId(new RequestId().id("test-id"));
         CanAccessResponse accessResponse = policyClient.canAccess(accessRequest);
         for (LeafResource resource: resources) {
             assertThat(accessResponse.getCanAccessResources(), hasItem(resource));
@@ -92,7 +97,6 @@ public class PolicyComponentTest extends PolicyTestCommon {
 
         // When the policies on the resource are requested
         GetPolicyRequest getRequest = new GetPolicyRequest().user(USER).resources(resources).context(CONTEXT);
-        getRequest.originalRequestId(new RequestId().id("test-id"));
         Map<LeafResource, Rules> getResponse = policyClient.getPolicySync(getRequest);
         LOGGER.info("Response: {}", getResponse);
 

--- a/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestCommon.java
+++ b/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestCommon.java
@@ -27,7 +27,6 @@ import uk.gov.gchq.palisade.resource.impl.FileResource;
 import uk.gov.gchq.palisade.resource.impl.SystemResource;
 import uk.gov.gchq.palisade.rule.PredicateRule;
 import uk.gov.gchq.palisade.service.request.Policy;
-//import uk.gov.gchq.palisade.service.policy.request.Policy;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestCommon.java
+++ b/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestCommon.java
@@ -26,7 +26,8 @@ import uk.gov.gchq.palisade.resource.impl.DirectoryResource;
 import uk.gov.gchq.palisade.resource.impl.FileResource;
 import uk.gov.gchq.palisade.resource.impl.SystemResource;
 import uk.gov.gchq.palisade.rule.PredicateRule;
-import uk.gov.gchq.palisade.service.policy.request.Policy;
+import uk.gov.gchq.palisade.service.request.Policy;
+//import uk.gov.gchq.palisade.service.policy.request.Policy;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestConfiguration.java
+++ b/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestConfiguration.java
@@ -33,20 +33,17 @@ public class PolicyTestConfiguration {
 
 
     @Bean
-    @Qualifier("policyConfiguration")
     public PolicyConfiguration policyConfiguration() {
         return new StdPolicyConfiguration();
     }
 
 
     @Bean
-    @Qualifier("userConfiguration")
     public UserConfiguration userConfiguration() {
         return new StdUserConfiguration();
     }
 
     @Bean
-    @Qualifier("policyService")
     public PolicyService policyService() {
         return new NullPolicyService();
     }

--- a/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestConfiguration.java
+++ b/policy-service-integration/src/test/java/uk/gov/gchq/palisade/integrationtests/policy/PolicyTestConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.palisade.integrationtests.policy;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import uk.gov.gchq.palisade.service.PolicyConfiguration;
+import uk.gov.gchq.palisade.service.UserConfiguration;
+import uk.gov.gchq.palisade.service.policy.config.StdPolicyConfiguration;
+import uk.gov.gchq.palisade.service.policy.config.StdUserConfiguration;
+import uk.gov.gchq.palisade.service.policy.service.NullPolicyService;
+import uk.gov.gchq.palisade.service.policy.service.PolicyService;
+
+
+@TestConfiguration
+public class PolicyTestConfiguration {
+
+
+    @Bean
+    @Qualifier("policyConfiguration")
+    public PolicyConfiguration policyConfiguration() {
+        return new StdPolicyConfiguration();
+    }
+
+
+    @Bean
+    @Qualifier("userConfiguration")
+    public UserConfiguration userConfiguration() {
+        return new StdUserConfiguration();
+    }
+
+    @Bean
+    @Qualifier("policyService")
+    public PolicyService policyService() {
+        return new NullPolicyService();
+    }
+}


### PR DESCRIPTION
This is a subtask of the PAL-550.  It refactors a few Policy integration tests that were needed to be updated after the changes for PAL-394. 